### PR TITLE
Parse attachment - Fixed multiple attachments handling issue

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,7 @@ export const RRULE_ICAL_KEY = 'RRULE';
 
 export const EXDATE_KEY = 'exdate';
 export const ATTENDEE_KEY = 'attendee';
+export const ATTACH_KEY = 'attach';
 export const ORGANIZER_KEY = 'organizer';
 export const ALARMS_KEY = 'alarms';
 

--- a/src/toJSON/utils/formatters.ts
+++ b/src/toJSON/utils/formatters.ts
@@ -1,6 +1,7 @@
 import {
   ALWAYS_STRING_VALUES,
   ATTENDEE_KEY,
+  ATTACH_KEY,
   EXDATE_KEY,
   MAILTO_KEY,
   MAILTO_KEY_WITH_DELIMITER,
@@ -349,9 +350,9 @@ export const formatStringToKeyValueObj = (
 
     // Handle nested array value, so it does not override with same key like
     // ATTENDEE
-    if (key === ATTENDEE_KEY) {
-      eventObj[ATTENDEE_KEY] = Array.isArray(eventObj[ATTENDEE_KEY])
-        ? [...eventObj[ATTENDEE_KEY], value]
+    if (key === ATTENDEE_KEY || key === ATTACH_KEY) {
+      eventObj[key] = Array.isArray(eventObj[key])
+        ? [...eventObj[key], value]
         : [value];
     } else if (key === EXDATE_KEY) {
       if (Array.isArray(value)) {


### PR DESCRIPTION
If there is multiple attachments for an event, current package parsed JSON contains only one attachment. I fixed issue to handle multiple attachments parsing.